### PR TITLE
[Breaking] Rename IndicatorSet to Indicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ Here is a summary of the sets defined by MathOptFormat.
 | `"PositiveSemidefiniteConeSquare"` | The cone of symmetric positive semidefinite matrices, with side length `side_dimension`. The entries of the matrix are given column by column (or equivalently, row by row). The matrix is both constrained to be symmetric and to be positive semidefinite. That is, if the functions in entries `(i, j)` and `(j, i)` are different, then a constraint will be added to make sure that the entries are equal. | {"type": "PositiveSemidefiniteConeSquare", "side_dimension": 2} |
 | `"PowerCone"` | [x, y, z] ∈ {R³: x^{exponent} y^{1-exponent} ≥ \|z\|; x, y ≥ 0} | {"type": "PowerCone", "exponent": 2.0} |
 | `"DualPowerCone"` | [u, v, w] ∈ {R³: (u / exponent)^{exponent} (v / (1-exponent))^{1-exponent} ≥ \|w\|; u, v ≥ 0} | {"type": "DualPowerCone", "exponent": 2.0} |
-| `"IndicatorSet"` | If `activate_on=one`: (y, x) ∈ {0,1}×Rᴺ: y = 0 ⟹ x ∈ S, otherwise when `activate_on=zero`: (y, x) ∈ {0,1}×Rᴺ: y = 1 ⟹ x ∈ S. | {"type": "IndicatorSet", "set": {"type": "LessThan", "upper": 2.0}, "activate_on": "one"} |
+| `"Indicator"` | If `activate_on=one`: (y, x) ∈ {0,1}×Rᴺ: y = 0 ⟹ x ∈ S, otherwise when `activate_on=zero`: (y, x) ∈ {0,1}×Rᴺ: y = 1 ⟹ x ∈ S. | {"type": "Indicator", "set": {"type": "LessThan", "upper": 2.0}, "activate_on": "one"} |
 | `"NormOneCone"` | (t, x) ∈ {R^{dimension}: t ≥ Σᵢ\|xᵢ\|} | {"type": "NormOneCone", "dimension": 2} |
 | `"NormInfinityCone"` | (t, x) ∈ {R^{dimension}: t ≥ maxᵢ\|xᵢ\|} | {"type": "NormInfinityCone", "dimension": 2} |
 | `"RelativeEntropyCone"` | (u, v, w) ∈ {R^{dimension}: u ≥ sumᵢ wᵢlog(wᵢ/vᵢ), vᵢ ≥ 0, wᵢ ≥ 0} | {"type": "RelativeEntropyCone", "dimension": 3} |

--- a/examples/biobjective.mof.json
+++ b/examples/biobjective.mof.json
@@ -2,7 +2,7 @@
     "description": "The problem: [min{2x - y + 1, -y}]",
     "version": {
         "major": 0,
-        "minor": 6
+        "minor": 7
     },
     "variables": [{
         "name": "x"

--- a/examples/milp.mof.json
+++ b/examples/milp.mof.json
@@ -2,7 +2,7 @@
     "description": "The problem: min{x | x + y >= 1, x ∈ [0, 1], y ∈ {0, 1}}",
     "version": {
         "major": 0,
-        "minor": 6
+        "minor": 7
     },
     "variables": [{
         "name": "x",

--- a/examples/nlp.mof.json
+++ b/examples/nlp.mof.json
@@ -2,7 +2,7 @@
     "description": "The problem: min{2x + sin(x)^2 + y}.",
     "version": {
         "major": 0,
-        "minor": 6
+        "minor": 7
     },
     "variables": [{
         "name": "x"

--- a/examples/quadratic.mof.json
+++ b/examples/quadratic.mof.json
@@ -2,7 +2,7 @@
     "description": "The problem: min{x^2 + x * y + y^2}",
     "version": {
         "major": 0,
-        "minor": 6
+        "minor": 7
     },
     "variables": [{
         "name": "x"

--- a/examples/vector.mof.json
+++ b/examples/vector.mof.json
@@ -2,7 +2,7 @@
     "description": "The problem: min{0 | [1 2; 3 4][x, y] + [5, 6] ∈ R+.",
     "version": {
         "major": 0,
-        "minor": 6
+        "minor": 7
     },
     "variables": [{
         "name": "x"

--- a/python/mof.py
+++ b/python/mof.py
@@ -2,6 +2,7 @@ import json
 import jsonschema
 import os
 
+
 SCHEMA_FILENAME = '../schemas/mof.0.7.schema.json'
 
 def validate(filename):

--- a/python/mof.py
+++ b/python/mof.py
@@ -5,14 +5,14 @@ import os
 SCHEMA_FILENAME = '../schemas/mof.0.6.schema.json'
 
 def validate(filename):
-    with open(filename, 'r') as io:
+    with open(filename, 'r', encoding='utf-8') as io:
         instance = json.load(io)
-    with open(SCHEMA_FILENAME, 'r') as io:
+    with open(SCHEMA_FILENAME, 'r', encoding='utf-8') as io:
         schema = json.load(io)
     jsonschema.validate(instance = instance, schema = schema)
 
 def summarize_schema():
-    with open(SCHEMA_FILENAME, 'r') as io:
+    with open(SCHEMA_FILENAME, 'r', encoding='utf-8') as io:
         schema = json.load(io)
     summary = "## Sets\n"
     summary += "\n### Scalar Sets\n\n" + summarize(schema, "scalar_sets")

--- a/python/mof.py
+++ b/python/mof.py
@@ -2,7 +2,7 @@ import json
 import jsonschema
 import os
 
-SCHEMA_FILENAME = '../schemas/mof.0.6.schema.json'
+SCHEMA_FILENAME = '../schemas/mof.0.7.schema.json'
 
 def validate(filename):
     with open(filename, 'r', encoding='utf-8') as io:

--- a/schemas/mof.0.7.schema.json
+++ b/schemas/mof.0.7.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json-schema.org/schema#",
-    "$id": "https://jump.dev/MathOptFormat/schemas/mof.0.6.schema.json",
+    "$id": "https://jump.dev/MathOptFormat/schemas/mof.0.7.schema.json",
     "title": "The schema for MathOptFormat",
     "type": "object",
     "required": ["version", "variables", "objective", "constraints"],

--- a/schemas/mof.0.7.schema.json
+++ b/schemas/mof.0.7.schema.json
@@ -1,0 +1,878 @@
+{
+    "$schema": "https://json-schema.org/schema#",
+    "$id": "https://jump.dev/MathOptFormat/schemas/mof.0.6.schema.json",
+    "title": "The schema for MathOptFormat",
+    "type": "object",
+    "required": ["version", "variables", "objective", "constraints"],
+    "properties": {
+        "version": {
+            "description": "The version of MathOptFormat that this schema validates against.",
+            "type": "object",
+            "required": ["minor", "major"],
+            "properties": {
+                "minor": {
+                    "const": 6
+                },
+                "major": {
+                    "const": 0
+                }
+            }
+        },
+        "name": {
+            "description": "The name of the model.",
+            "type": "string"
+        },
+        "author": {
+            "description": "The author of the model for citation purposes.",
+            "type": "string"
+        },
+        "description": {
+            "description": "A human-readable description of the model.",
+            "type": "string"
+        },
+        "variables": {
+            "description": "An array of variables in the model. Each must have a unique name.",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": ["name"],
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "primal_start": {
+                        "description": "An initial value that the optimizer may use to warm-start the solution process.",
+                        "type": "number"
+                    }
+                }
+            },
+            "uniqueItems": true
+        },
+        "objective": {
+            "description": "The objective of the model.",
+            "type": "object",
+            "required": ["sense"],
+            "oneOf": [{
+                "properties": {
+                    "sense": {
+                        "enum": ["min", "max"]
+                    },
+                    "function": {
+                        "oneOf": [{
+                            "$ref": "#/definitions/scalar_functions"
+                        }, {
+                            "$ref": "#/definitions/vector_functions"
+                        }]
+                    }
+                }
+            }, {
+                "properties": {
+                    "sense": {
+                        "const": "feasibility"
+                    }
+                }
+            }]
+        },
+        "constraints": {
+            "description": "An array of constraints in the model. Scalar-valued functions can only be paired with scalar-sets, and the same applies for vector-valued functions and sets.",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": ["function", "set"],
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    }
+                },
+                "oneOf": [{
+                    "description": "A scalar-valued constraint.",
+                    "properties": {
+                        "function": {
+                            "$ref": "#/definitions/scalar_functions"
+                        },
+                        "set": {
+                            "$ref": "#/definitions/scalar_sets"
+                        }
+                    }
+                }, {
+                    "description": "A vector-valued constraint.",
+                    "properties": {
+                        "function": {
+                            "$ref": "#/definitions/vector_functions"
+                        },
+                        "set": {
+                            "$ref": "#/definitions/vector_sets"
+                        }
+                    }
+                }]
+            },
+            "uniqueItems": true
+        }
+    },
+    "definitions": {
+        "ScalarAffineTerm": {
+            "description": "A helper object that represents `coefficent * variable`.",
+            "type": "object",
+            "required": ["coefficient", "variable"],
+            "properties": {
+                "coefficient": {
+                    "type": "number"
+                },
+                "variable": {
+                    "type": "string"
+                }
+            }
+        },
+        "ScalarQuadraticTerm": {
+            "description": "A helper object that represents `coefficent * variable_1 * variable_2`.",
+            "type": "object",
+            "required": ["coefficient", "variable_1", "variable_2"],
+            "properties": {
+                "coefficient": {
+                    "type": "number"
+                },
+                "variable_1": {
+                    "type": "string"
+                },
+                "variable_2": {
+                    "type": "string"
+                }
+            }
+        },
+        "VectorAffineTerm": {
+            "description": "A helper object that represents a `ScalarAffineTerm` in row `output_index`.",
+            "type": "object",
+            "required": ["output_index", "scalar_term"],
+            "properties": {
+                "output_index": {
+                    "type": "integer",
+                    "minimum": 1
+                },
+                "scalar_term": {
+                    "$ref": "#/definitions/ScalarAffineTerm"
+                }
+            }
+        },
+        "VectorQuadraticTerm": {
+            "description": "A helper object that represents a `ScalarQuadraticTerm` in row `output_index`.",
+            "type": "object",
+            "required": ["output_index", "scalar_term"],
+            "properties": {
+                "output_index": {
+                    "type": "integer",
+                    "minimum": 1
+                },
+                "scalar_term": {
+                    "$ref": "#/definitions/ScalarQuadraticTerm"
+                }
+            }
+        },
+        "NonlinearTerm": {
+            "description": "A node in an expresion graph representing a nonlinear function.",
+            "type": "object",
+            "required": ["type"],
+            "oneOf": [{
+                "description": "Unary operators",
+                "required": ["args"],
+                "properties": {
+                    "type": {
+                        "enum": [
+                            "log", "log10", "exp", "sqrt", "floor", "ceil",
+                            "abs", "cos", "sin", "tan", "acos", "asin", "atan",
+                            "cosh", "sinh", "tanh", "acosh", "asinh", "atanh"
+                        ]
+                    },
+                    "args": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/definitions/NonlinearTerm"
+                        },
+                        "minItems": 1,
+                        "maxItems": 1
+                    }
+                }
+            }, {
+                "description": "Binary operators",
+                "required": ["args"],
+                "properties": {
+                    "type": {
+                        "enum": ["/", "^"]
+                    },
+                    "args": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/definitions/NonlinearTerm"
+                        },
+                        "minItems": 2,
+                        "maxItems": 2
+                    }
+                }
+            }, {
+                "description": "N-ary operators",
+                "required": ["args"],
+                "properties": {
+                    "type": {
+                        "enum": ["+", "-", "*", "min", "max"]
+                    },
+                    "args": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/definitions/NonlinearTerm"
+                        },
+                        "minItems": 1
+                    }
+                }
+            }, {
+                "description": "A real-valued numeric constant",
+                "examples": ["{\"type\": \"real\", \"value\": 1.0}"],
+                "required": ["value"],
+                "properties": {
+                    "type": {
+                        "const": "real"
+                    },
+                    "value": {
+                        "type": "number"
+                    }
+                }
+            }, {
+                "description": "A complex-valued numeric constant",
+                "examples": ["{\"type\": \"complex\", \"real\": 1.0, \"imag\": 2.0}"],
+                "required": ["real", "imag"],
+                "properties": {
+                    "type": {
+                        "const": "complex"
+                    },
+                    "real": {
+                        "type": "number"
+                    },
+                    "imag": {
+                        "type": "number"
+                    }
+                }
+            }, {
+                "description": "A reference to an optimization variable",
+                "examples": ["{\"type\": \"variable\", \"name\": \"x\"}"],
+                "required": ["name"],
+                "properties": {
+                    "type": {
+                        "const": "variable"
+                    },
+                    "name": {
+                        "type": "string"
+                    }
+                }
+            }, {
+                "description": "A pointer to a (1-indexed) element in the `node_list` field in a nonlinear function",
+                "examples": ["{\"type\": \"node\", \"index\": 2}"],
+                "required": ["index"],
+                "properties": {
+                    "type": {
+                        "const": "node"
+                    },
+                    "index": {
+                        "type": "integer",
+                        "minimum": 1
+                    }
+                }
+            }]
+        },
+        "scalar_functions": {
+            "description": "A schema for the scalar-valued functions defined by MathOptFormat.See http://www.juliaopt.org/MathOptInterface.jl/v0.8/apireference/#Functions-and-function-modifications-1 for a list of the functions and their meanings.",
+            "type": "object",
+            "required": ["type"],
+            "oneOf": [{
+                "description": "The scalar variable `variable`.",
+                "examples": ["{\"type\": \"SingleVariable\", \"variable\": \"x\"}"],
+                "required": ["variable"],
+                "properties": {
+                    "type": {
+                        "const": "SingleVariable"
+                    },
+                    "variable": {
+                        "type": "string"
+                    }
+                }
+            }, {
+                "description": "The function `a'x + b`, where `a` is a sparse vector specified by a list of `ScalarAffineTerm`s in `terms` and `b` is the scalar in `constant`. Duplicate variables in `terms` are accepted, and the corresponding coefficients are summed together.",
+                "examples": ["{\"type\": \"ScalarAffineFunction\", \"constant\": 1.0, \"terms\": [{\"coefficient\": 2.5, \"variable\": \"x\"}]}"],
+                "required": ["constant", "terms"],
+                "properties": {
+                    "type": {
+                        "const": "ScalarAffineFunction"
+                    },
+                    "constant": {
+                        "type": "number"
+                    },
+                    "terms": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/definitions/ScalarAffineTerm"
+                        }
+                    }
+                }
+            }, {
+                "description": "The function `0.5x'Qx + a'x + b`, where `a` is a sparse vector of `ScalarAffineTerm`s in `affine_terms`, `b` is the scalar `constant`, and `Q` is a symmetric matrix specified by a list of `ScalarQuadraticTerm`s in `quadratic_terms`. Duplicate indices in `affine_terms` and `quadratic` are accepted, and the corresponding coefficients are summed together. Mirrored indices in `quadratic_terms` (i.e., `(i,j)` and `(j, i)`) are considered duplicates; only one need to be specified.",
+                "examples": ["{\"type\": \"ScalarQuadraticFunction\", \"constant\": 1.0, \"affine_terms\": [{\"coefficient\": 2.5, \"variable\": \"x\"}], \"quadratic_terms\": [{\"coefficient\": 2.0, \"variable_1\": \"x\", \"variable_2\": \"y\"}]}"],
+                "required": ["constant", "affine_terms", "quadratic_terms"],
+                "properties": {
+                    "type": {
+                        "const": "ScalarQuadraticFunction"
+                    },
+                    "constant": {
+                        "type": "number"
+                    },
+                    "affine_terms": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/definitions/ScalarAffineTerm"
+                        }
+                    },
+                    "quadratic_terms": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/definitions/ScalarQuadraticTerm"
+                        }
+                    }
+                }
+            }, {
+                "description": "An expression graph representing a scalar nonlinear function.",
+                "required": ["root", "node_list"],
+                "properties": {
+                    "type": {
+                        "const": "ScalarNonlinearFunction"
+                    },
+                    "root": {
+                        "$ref": "#/definitions/NonlinearTerm"
+                    },
+                    "node_list": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/definitions/NonlinearTerm"
+                        }
+                    }
+                }
+            }]
+        },
+        "vector_functions": {
+            "description": "A schema for the vector-valued functions defined by MathOptFormat.See http://www.juliaopt.org/MathOptInterface.jl/v0.8/apireference/#Functions-and-function-modifications-1 for a list of the functions and their meanings.",
+            "type": "object",
+            "required": ["type"],
+            "oneOf": [{
+                "description": "An ordered list of variables.",
+                "examples": ["{\"type\": \"VectorOfVariables\", \"variables\": [\"x\", \"y\"]}"],
+                "required": ["variables"],
+                "properties": {
+                    "type": {
+                        "const": "VectorOfVariables"
+                    },
+                    "variables": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }, {
+                "description": "The function `Ax + b`, where `A` is a sparse matrix specified by a list of `VectorAffineTerm`s in `terms` and `b` is a dense vector specified by `constants`.",
+                "examples": ["{\"type\": \"VectorAffineFunction\", \"constants\": [1.0], \"terms\": [{\"output_index\": 1, \"scalar_term\": {\"coefficient\": 2.5, \"variable\": \"x\"}}]}"],
+                "required": ["constants", "terms"],
+                "properties": {
+                    "type": {
+                        "const": "VectorAffineFunction"
+                    },
+                    "constants": {
+                        "type": "array",
+                        "items": {
+                            "type": "number"
+                        }
+                    },
+                    "terms": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/definitions/VectorAffineTerm"
+                        }
+                    }
+                }
+            }, {
+                "description": "The vector-valued quadratic function `q(x) + Ax + b`, where `q(x)` is specified by a list of `VectorQuadraticTerm`s in `quadratic_terms`, `A` is a sparse matrix specified by a list of `VectorAffineTerm`s in `affine_terms` and `b` is a dense vector specified by `constants`.",
+                "required": ["constants", "affine_terms", "quadratic_terms"],
+                "properties": {
+                    "type": {
+                        "const": "VectorQuadraticFunction"
+                    },
+                    "constants": {
+                        "type": "array",
+                        "items": {
+                            "type": "number"
+                        }
+                    },
+                    "affine_terms": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/definitions/VectorAffineTerm"
+                        }
+                    },
+                    "quadratc_terms": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/definitions/VectorQuadraticTerm"
+                        }
+                    }
+                }
+            }]
+        },
+        "scalar_sets": {
+            "description": "A schema for the scalar-valued sets defined by MathOptFormat. See http: //www.juliaopt.org/MathOptInterface.jl/v0.8/apireference/#Sets-1 for a list of the sets and their meanings.",
+            "type": "object",
+            "required": ["type"],
+            "oneOf": [{
+                "description": "(-∞, upper]",
+                "examples": ["{\"type\": \"LessThan\", \"upper\": 2.1}"],
+                "required": ["upper"],
+                "properties": {
+                    "type": {
+                        "const": "LessThan"
+                    },
+                    "upper": {
+                        "type": "number"
+                    }
+                }
+            }, {
+                "description": "[lower, ∞)",
+                "examples": ["{\"type\": \"GreaterThan\", \"lower\": 2.1}"],
+                "required": ["lower"],
+                "properties": {
+                    "type": {
+                        "const": "GreaterThan"
+                    },
+                    "lower": {
+                        "type": "number"
+                    }
+                }
+            }, {
+                "description": "{value}",
+                "examples": ["{\"type\": \"EqualTo\", \"value\": 2.1}"],
+                "required": ["value"],
+                "properties": {
+                    "type": {
+                        "const": "EqualTo"
+                    },
+                    "value": {
+                        "type": "number"
+                    }
+                }
+            }, {
+                "description": "[lower, upper]",
+                "examples": ["{\"type\": \"Interval\", \"lower\": 2.1, \"upper\": 3.4}"],
+                "required": ["lower", "upper"],
+                "properties": {
+                    "type": {
+                        "const": "Interval"
+                    },
+                    "lower": {
+                        "type": "number"
+                    },
+                    "upper": {
+                        "type": "number"
+                    }
+                }
+            }, {
+                "description": "{0} ∪ {lower, lower + 1, ..., upper}",
+                "examples": ["{\"type\": \"Semiinteger\", \"lower\": 2, \"upper\": 4}"],
+                "required": ["lower", "upper"],
+                "properties": {
+                    "type": {
+                        "const": "Semiinteger"
+                    },
+                    "lower": {
+                        "type": "number"
+                    },
+                    "upper": {
+                        "type": "number"
+                    }
+                }
+            }, {
+                "description": "{0} ∪ [lower, upper]",
+                "examples": ["{\"type\": \"Semicontinuous\", \"lower\": 2.1, \"upper\": 3.4}"],
+                "required": ["lower", "upper"],
+                "properties": {
+                    "type": {
+                        "const": "Semicontinuous"
+                    },
+                    "lower": {
+                        "type": "number"
+                    },
+                    "upper": {
+                        "type": "number"
+                    }
+                }
+            }, {
+                "description": "{0, 1}",
+                "examples": ["{\"type\": \"ZeroOne\"}"],
+                "properties": {
+                    "type": {
+                        "const": "ZeroOne"
+                    }
+                }
+            }, {
+                "description": "ℤ",
+                "examples": ["{\"type\": \"Integer\"}"],
+                "properties": {
+                    "type": {
+                        "const": "Integer"
+                    }
+                }
+            }]
+        },
+        "vector_sets": {
+            "description": "A schema for the vector-valued sets defined by MathOptFormat. See http: //www.juliaopt.org/MathOptInterface.jl/v0.8/apireference/#Sets-1 for a list of the sets and their meanings.",
+            "type": "object",
+            "required": ["type"],
+            "oneOf": [{
+                "description": "[x, y, z] ∈ {R³: y * exp(x / y) ≤ z, y ≥ 0}",
+                "examples": ["{\"type\": \"ExponentialCone\"}"],
+                "properties": {
+                    "type": {
+                        "const": "ExponentialCone"
+                    }
+                }
+            }, {
+                "description": "[u, v, w] ∈ {R³: -u * exp(v / u) ≤ exp(1) * w, u < 0}",
+                "examples": ["{\"type\": \"DualExponentialCone\"}"],
+                "properties": {
+                    "type": {
+                        "const": "DualExponentialCone"
+                    }
+                }
+            }, {
+                "description": "A special ordered set of type I.",
+                "examples": ["{\"type\": \"SOS1\", \"weights\": [1, 3, 2]}"],
+                "required": ["weights"],
+                "properties": {
+                    "type": {
+                        "const": "SOS1"
+                    },
+                    "weights": {
+                        "type": "array",
+                        "items": {
+                            "type": "number"
+                        }
+                    }
+                }
+            }, {
+                "description": "A special ordered set of type II.",
+                "examples": ["{\"type\": \"SOS2\", \"weights\": [1, 3, 2]}"],
+                "required": ["weights"],
+                "properties": {
+                    "type": {
+                        "const": "SOS2"
+                    },
+                    "weights": {
+                        "type": "array",
+                        "items": {
+                            "type": "number"
+                        }
+                    }
+                }
+            }, {
+                "description": "[t, x] ∈ {R^{dimension}: t ≤ (Πxᵢ)^{1 / (dimension-1)}}",
+                "examples": ["{\"type\": \"GeometricMeanCone\", \"dimension\": 3}"],
+                "required": ["dimension"],
+                "properties": {
+                    "type": {
+                        "const": "GeometricMeanCone"
+                    },
+                    "dimension": {
+                        "type": "integer",
+                        "minimum": 1
+                    }
+                }
+            }, {
+                "description": "[t, x] ∈ {R^{dimension} : t ≥ ||x||₂",
+                "examples": ["{\"type\": \"SecondOrderCone\", \"dimension\": 3}"],
+                "required": ["dimension"],
+                "properties": {
+                    "type": {
+                        "const": "SecondOrderCone"
+                    },
+                    "dimension": {
+                        "type": "integer",
+                        "minimum": 1
+                    }
+                }
+            }, {
+                "description": "[t, u, x] ∈ {R^{dimension} : 2tu ≥ (||x||₂)²; t, u ≥ 0}",
+                "examples": ["{\"type\": \"RotatedSecondOrderCone\", \"dimension\": 3}"],
+                "required": ["dimension"],
+                "properties": {
+                    "type": {
+                        "const": "RotatedSecondOrderCone"
+                    },
+                    "dimension": {
+                        "type": "integer",
+                        "minimum": 1
+                    }
+                }
+            }, {
+                "description": "{0}^{dimension}",
+                "examples": ["{\"type\": \"Zeros\", \"dimension\": 3}"],
+                "required": ["dimension"],
+                "properties": {
+                    "type": {
+                        "const": "Zeros"
+                    },
+                    "dimension": {
+                        "type": "integer",
+                        "minimum": 1
+                    }
+                }
+            }, {
+                "description": "R^{dimension}",
+                "examples": ["{\"type\": \"Reals\", \"dimension\": 3}"],
+                "required": ["dimension"],
+                "properties": {
+                    "type": {
+                        "const": "Reals"
+                    },
+                    "dimension": {
+                        "type": "integer",
+                        "minimum": 1
+                    }
+                }
+            }, {
+                "description": "R₋^{dimension}",
+                "examples": ["{\"type\": \"Nonpositives\", \"dimension\": 3}"],
+                "required": ["dimension"],
+                "properties": {
+                    "type": {
+                        "const": "Nonpositives"
+                    },
+                    "dimension": {
+                        "type": "integer",
+                        "minimum": 1
+                    }
+                }
+            }, {
+                "description": "R₊^{dimension}",
+                "examples": ["{\"type\": \"Nonnegatives\", \"dimension\": 3}"],
+                "required": ["dimension"],
+                "properties": {
+                    "type": {
+                        "const": "Nonnegatives"
+                    },
+                    "dimension": {
+                        "type": "integer",
+                        "minimum": 1
+                    }
+                }
+            }, {
+                "description": "{[t, X] ∈ R^{1 + d(d+1)/2} : t ≤ det(X)^{1/d}}, where the matrix `X` is represented in the same symmetric packed format as in the `PositiveSemidefiniteConeTriangle`. The argument `side_dimension` is the side dimension of the matrix `X`, i.e., its number of rows or columns.",
+                "examples": ["{\"type\": \"RootDetConeTriangle\", \"side_dimension\": 2}"],
+                "required": ["side_dimension"],
+                "properties": {
+                    "type": {
+                        "const": "RootDetConeTriangle"
+                    },
+                    "side_dimension": {
+                        "type": "integer",
+                        "minimum": 1
+                    }
+                }
+            }, {
+                "description": "{[t, X] ∈ R^{1 + d^2} : t ≤ det(X)^{1/d}, X symmetric}, where the matrix `X` is represented in the same symmetric packed format as in the `PositiveSemidefiniteConeSquare`. The argument `side_dimension` is the side dimension of the matrix `X`, i.e., its number of rows or columns.",
+                "examples": ["{\"type\": \"RootDetConeSquare\", \"side_dimension\": 2}"],
+                "required": ["side_dimension"],
+                "properties": {
+                    "type": {
+                        "const": "RootDetConeSquare"
+                    },
+                    "side_dimension": {
+                        "type": "integer",
+                        "minimum": 1
+                    }
+                }
+            }, {
+                "description": "{[t, u, X] ∈ R^{2 + d(d+1)/2} : t ≤ u log(det(X/u)), u > 0}, where the matrix `X` is represented in the same symmetric packed format as in the `PositiveSemidefiniteConeTriangle`. The argument `side_dimension` is the side dimension of the matrix `X`, i.e., its number of rows or columns.",
+                "examples": ["{\"type\": \"LogDetConeTriangle\", \"side_dimension\": 2}"],
+                "required": ["side_dimension"],
+                "properties": {
+                    "type": {
+                        "const": "LogDetConeTriangle"
+                    },
+                    "side_dimension": {
+                        "type": "integer",
+                        "minimum": 1
+                    }
+                }
+            }, {
+                "description": "{[t, u, X] ∈ R^{2 + d^2} : t ≤ u log(det(X/u)), X symmetric, u > 0}, where the matrix `X` is represented in the same symmetric packed format as in the `PositiveSemidefiniteConeSquare`. The argument `side_dimension` is the side dimension of the matrix `X`, i.e., its number of rows or columns.",
+                "examples": ["{\"type\": \"LogDetConeSquare\", \"side_dimension\": 2}"],
+                "required": ["side_dimension"],
+                "properties": {
+                    "type": {
+                        "const": "LogDetConeSquare"
+                    },
+                    "side_dimension": {
+                        "type": "integer",
+                        "minimum": 1
+                    }
+                }
+            }, {
+                "description": "The (vectorized) cone of symmetric positive semidefinite matrices, with `side_dimension` rows and columns. The entries of the upper-right triangular part of the matrix are given column by column (or equivalently, the entries of the lower-left triangular part are given row by row).",
+                "examples": ["{\"type\": \"PositiveSemidefiniteConeTriangle\", \"side_dimension\": 2}"],
+                "required": ["side_dimension"],
+                "properties": {
+                    "type": {
+                        "const": "PositiveSemidefiniteConeTriangle"
+                    },
+                    "side_dimension": {
+                        "type": "integer",
+                        "minimum": 1
+                    }
+                }
+            }, {
+                "description": "The cone of symmetric positive semidefinite matrices, with side length `side_dimension`. The entries of the matrix are given column by column (or equivalently, row by row). The matrix is both constrained to be symmetric and to be positive semidefinite. That is, if the functions in entries `(i, j)` and `(j, i)` are different, then a constraint will be added to make sure that the entries are equal.",
+                "examples": ["{\"type\": \"PositiveSemidefiniteConeSquare\", \"side_dimension\": 2}"],
+                "required": ["side_dimension"],
+                "properties": {
+                    "type": {
+                        "const": "PositiveSemidefiniteConeSquare"
+                    },
+                    "side_dimension": {
+                        "type": "integer",
+                        "minimum": 1
+                    }
+                }
+            }, {
+                "description": "[x, y, z] ∈ {R³: x^{exponent} y^{1-exponent} ≥ |z|; x, y ≥ 0}",
+                "examples": ["{\"type\": \"PowerCone\", \"exponent\": 2.0}"],
+                "required": ["exponent"],
+                "properties": {
+                    "type": {
+                        "const": "PowerCone"
+                    },
+                    "exponent": {
+                        "type": "number"
+                    }
+                }
+            }, {
+                "description": "[u, v, w] ∈ {R³: (u / exponent)^{exponent} (v / (1-exponent))^{1-exponent} ≥ |w|; u, v ≥ 0}",
+                "examples": ["{\"type\": \"DualPowerCone\", \"exponent\": 2.0}"],
+                "required": ["exponent"],
+                "properties": {
+                    "type": {
+                        "const": "DualPowerCone"
+                    },
+                    "exponent": {
+                        "type": "number"
+                    }
+                }
+            }, {
+                "description": "If `activate_on=one`: (y, x) ∈ {0,1}×Rᴺ: y = 0 ⟹ x ∈ S, otherwise when `activate_on=zero`: (y, x) ∈ {0,1}×Rᴺ: y = 1 ⟹ x ∈ S.",
+                "examples": ["{\"type\": \"Indicator\", \"set\": {\"type\": \"LessThan\", \"upper\": 2.0}, \"activate_on\": \"one\"}"],
+                "required": ["set", "activate_on"],
+                "properties": {
+                    "type": {
+                        "const": "Indicator"
+                    },
+                    "set": {
+                        "oneOf": [{
+                            "$ref": "#/definitions/scalar_sets"
+                        }, {
+                            "$ref": "#/definitions/vector_sets"
+                        }]
+                    },
+                    "activate_on": {
+                        "enum": ["one", "zero"]
+                    }
+                }
+            }, {
+                "description": "(t, x) ∈ {R^{dimension}: t ≥ Σᵢ|xᵢ|}",
+                "examples": ["{\"type\": \"NormOneCone\", \"dimension\": 2}"],
+                "required": ["dimension"],
+                "properties": {
+                    "type": {
+                        "const": "NormOneCone"
+                    },
+                    "dimension": {
+                        "type": "integer",
+                        "minimum": 2
+                    }
+                }
+            }, {
+                "description": "(t, x) ∈ {R^{dimension}: t ≥ maxᵢ|xᵢ|}",
+                "examples": ["{\"type\": \"NormInfinityCone\", \"dimension\": 2}"],
+                "required": ["dimension"],
+                "properties": {
+                    "type": {
+                        "const": "NormInfinityCone"
+                    },
+                    "dimension": {
+                        "type": "integer",
+                        "minimum": 2
+                    }
+                }
+            }, {
+                "description": "(u, v, w) ∈ {R^{dimension}: u ≥ Σᵢ wᵢlog(wᵢ/vᵢ), vᵢ ≥ 0, wᵢ ≥ 0}",
+                "examples": ["{\"type\": \"RelativeEntropyCone\", \"dimension\": 3}"],
+                "required": ["dimension"],
+                "properties": {
+                    "type": {
+                        "const": "RelativeEntropyCone"
+                    },
+                    "dimension": {
+                        "type": "integer",
+                        "minimum": 3
+                    }
+                }
+            }, {
+                "description": "(t, X) ∈ {R^{1+row_dim×column_dim}: t ≥ σ₁(X)}",
+                "examples": ["{\"type\": \"NormSpectralCone\", \"row_dim\": 1, \"column_dim\": 2}"],
+                "required": ["row_dim", "column_dim"],
+                "properties": {
+                    "type": {
+                        "const": "NormSpectralCone"
+                    },
+                    "row_dim": {
+                        "type": "integer",
+                        "minimum": 1
+                    },
+                    "column_dim": {
+                        "type": "integer",
+                        "minimum": 1
+                    }
+                }
+            }, {
+                "description": "(t, X) ∈ {R^{1+row_dim×column_dim}: t ≥ Σᵢ σᵢ(X)}",
+                "examples": ["{\"type\": \"NormNuclearCone\", \"row_dim\": 1, \"column_dim\": 2}"],
+                "required": ["row_dim", "column_dim"],
+                "properties": {
+                    "type": {
+                        "const": "NormNuclearCone"
+                    },
+                    "row_dim": {
+                        "type": "integer",
+                        "minimum": 1
+                    },
+                    "column_dim": {
+                        "type": "integer",
+                        "minimum": 1
+                    }
+                }
+            }, {
+                "description": "The set corresponding to a mixed complementarity constraint. Complementarity constraints should be specified with an AbstractVectorFunction-in-Complements(dimension) constraint. The dimension of the vector-valued function `F` must be `dimension`. This defines a complementarity constraint between the scalar function `F[i]` and the variable in `F[i + dimension/2]`. Thus, `F[i + dimension/2]` must be interpretable as a single variable `x_i` (e.g., `1.0 * x + 0.0`). The mixed complementarity problem consists of finding `x_i` in the interval `[lb, ub]` (i.e., in the set `Interval(lb, ub)`), such that the following holds: 1. `F_i(x) == 0` if `lb_i < x_i < ub_i`; 2. `F_i(x) >= 0` if `lb_i == x_i`; 3. `F_i(x) <= 0` if `x_i == ub_i`. Classically, the bounding set for `x_i` is `Interval(0, Inf)`, which recovers: `0 <= F_i(x) ⟂ x_i >= 0`, where the `⟂` operator implies `F_i(x) * x_i = 0`.",
+                "examples": ["{\"type\": \"Complements\", \"dimension\": 2}"],
+                "required": ["dimension"],
+                "properties": {
+                    "type": {
+                        "const": "Complements"
+                    },
+                    "dimension": {
+                        "type": "integer",
+                        "minimum": 2
+                    }
+                }
+            }]
+        }
+    }
+}


### PR DESCRIPTION
Follows https://github.com/jump-dev/MathOptInterface.jl/pull/1475 and https://github.com/jump-dev/MathOptInterface.jl/issues/1459. 

I created a new file for v0.7, I thought this would be the most convenient (especially as this change cannot be part of v0.6.x). 